### PR TITLE
Typings fix

### DIFF
--- a/src/types/WebApiClient.d.ts
+++ b/src/types/WebApiClient.d.ts
@@ -1,6 +1,6 @@
 import * as bluebird from "bluebird";
 
-declare module WebApiClient {
+export module WebApiClient {
     let ApiVersion: string;
     let ReturnAllPages: boolean;
     let PrettifyErrors: boolean;
@@ -443,5 +443,3 @@ declare module WebApiClient {
         class WinQuoteRequest extends Request { }
     }
 }
-
-export default WebApiClient;


### PR DESCRIPTION
Hi @DigitalFlow,

I've found it difficult to make it work with typescript. When I've tried to import it with line:
`import { WebApiClient } from "xrm-webapi-client"` it shows error that `..../WebApiClient has no exported member 'WebApiClient'`. I've fixed it by changing typings as in this pull request. Please take a look at this.